### PR TITLE
Update leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,27 +8,25 @@ A curated list of AWESOME blogs, videos, tutorials, code, tools, scripts. Anythi
 
 | Top-level Domain                | Number of Posts |
 |---------------------------------|-----------------|
-| 🏆 **charbelnemnom.com**        | 14              |
-| 🥈 **blog.tyang.org**           | 13              |
-| 🥉 **andrewmatveychuk.com**     | 10              |
-| medium.com                      | 9               |
+| 🏆 **blog.tyang.org**           | 18              |
+| 🥈 **charbelnemnom.com**        | 14              |
+| 🥉 **andrewmatveychuk.com**     | 9               |
 | jloudon.com                     | 8               |
-| adinermie.com                   | 7               |
-| www.stefanroth.net              | 6               |
-| azsec.azurewebsites.net         | 6               |
+| adinermie.com                   | 6               |
+| www.stefanroth.net              | 5               |
 | www.georgeollis.com             | 5               |
-| www.cloudsma.com                | 5               |
-| samcogan.com                    | 4               |
-| autosysops.com                  | 4               |
-| www.m365princess.com            | 4               |
-| checinski.cloud                 | 3               |
-| manbearpiet.com                 | 3               |
+| www.cloudsma.com                | 4               |
+| wedoazure.ie                    | 4               |
+| www.m365princess.com            | 3               |
 | cloudadministrator.net          | 3               |
-| blog.djurasovic.com             | 3               |
-| www.thomasmaurer.ch             | 3               |
 | www.danielstechblog.io          | 3               |
-| wedoazure.ie                    | 3               |
 | yourazurecoach.com              | 3               |
+| autosysops.com                  | 2               |
+| samcogan.com                    | 2               |
+| checinski.cloud                 | 2               |
+| manbearpiet.com                 | 2               |
+| blog.djurasovic.com             | 2               |
+| www.thomasmaurer.ch             | 2               |
 | amdocs.com                      | 1               |
 
 ## Microsoft Learn


### PR DESCRIPTION
Updates to domain rankings and post counts:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L11-R29): Updated the rankings and post counts for several domains, including promoting `blog.tyang.org` to the top position with 18 posts, adjusting counts for `charbelnemnom.com`, `andrewmatveychuk.com`, and others, and adding new entries such as `wedoazure.ie`.